### PR TITLE
Chem init

### DIFF
--- a/idaes/models/properties/modular_properties/reactions/equilibrium_forms.py
+++ b/idaes/models/properties/modular_properties/reactions/equilibrium_forms.py
@@ -189,7 +189,6 @@ class solubility_product:
         if Qunits is not None:
             Q = Q / Qunits
 
-        #return s - smooth_max(0, s - Q, rblock.eps) == 0
         return Q - smooth_max(0, Q - s / (s+b.k_eq[r_idx]), rblock.eps) == 0
     
     @staticmethod
@@ -288,9 +287,6 @@ class log_solubility_product:
         Q = b.log_k_eq[r_idx] - e
         # Q should be unitless due to log form
 
-        #return s - smooth_max(0, s - Q, rblock.eps) == 0
-        # Flip s and Q and use s/(s+tol) so that it stays within 0-1, 
-        # then it's safe to use single scale to this constraint.
         s = s *10/ (s+b.k_eq[r_idx])
         return Q - smooth_max(0, Q - s, rblock.eps) == 0
 

--- a/idaes/models/properties/modular_properties/reactions/equilibrium_forms.py
+++ b/idaes/models/properties/modular_properties/reactions/equilibrium_forms.py
@@ -189,8 +189,9 @@ class solubility_product:
         if Qunits is not None:
             Q = Q / Qunits
 
-        return s - smooth_max(0, s - Q, rblock.eps) == 0
-
+        #return s - smooth_max(0, s - Q, rblock.eps) == 0
+        return Q - smooth_max(0, Q - s / (s+b.k_eq[r_idx]), rblock.eps) == 0
+    
     @staticmethod
     def calculate_scaling_factors(b, sf_keq):
         return sf_keq
@@ -287,7 +288,11 @@ class log_solubility_product:
         Q = b.log_k_eq[r_idx] - e
         # Q should be unitless due to log form
 
-        return s - smooth_max(0, s - Q, rblock.eps) == 0
+        #return s - smooth_max(0, s - Q, rblock.eps) == 0
+        # Flip s and Q and use s/(s+tol) so that it stays within 0-1, 
+        # then it's safe to use single scale to this constraint.
+        s = s *10/ (s+b.k_eq[r_idx])
+        return Q - smooth_max(0, Q - s, rblock.eps) == 0
 
     @staticmethod
     def calculate_scaling_factors(b, sf_keq):

--- a/idaes/models/properties/modular_properties/state_definitions/FpcTP.py
+++ b/idaes/models/properties/modular_properties/state_definitions/FpcTP.py
@@ -142,7 +142,7 @@ def define_state(b):
 
     b.mole_frac_phase_comp = Var(
         b.phase_component_set,
-        bounds=(1e-20, 1.001),
+        bounds=(1e-50, 1.001),
         initialize=1 / len(b.component_list),
         doc="Phase mole fractions",
         units=pyunits.dimensionless,


### PR DESCRIPTION
## Fixes
pH-dependent solubility tests from WaterTAP

## Summary/Motivation:

This solubility equilibrium constraint used a smoothing strategy to compare precipitate amount s and the solution state Q. Only one of s and Q can be greater than zero at any time. When s and Q differ in several orders of magnitude, the problem becomes hard to scale, especially when Q is in log form, the original formulation will sacrifice the accuracy of s, the precipitate amount, which could be very small (i.e., 1e-10) and important in water-related applications.

Fix outside of bounds warning in the initialization of pH-dependent solubility tests.

## Changes proposed in this PR:
- Normalize the precipitate amount s to be 0-1 with respect to its solubility product constant Ksp.

- Update mole_frac_phase_comp bounds in FpcTP to be consistent with log_mole_frac_phase_comp bounds.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
